### PR TITLE
feat(initializer, create-config): disable spinnies option

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ create('sessionName', qrCallback, statusFind, {
   logQR: true, // Logs QR automatically in terminal
   browserArgs: [''], // Parameters to be added into the chrome browser instance
   refreshQR: 15000, // Will refresh QR every 15 seconds, 0 will load QR once. Default is 30 seconds
+  disableSpins: true, // Will disable Spinnies animation, useful for containers (docker) for a better log
 });
 ```
 

--- a/src/config/create-config.ts
+++ b/src/config/create-config.ts
@@ -61,6 +61,7 @@ export interface CreateConfig {
   browserArgs?: string[];
   logQR?: boolean;
   refreshQR?: number;
+  disableSpins?: boolean;
 }
 
 export const defaultOptions: CreateConfig = {
@@ -71,4 +72,5 @@ export const defaultOptions: CreateConfig = {
   logQR: true,
   browserArgs: [''],
   refreshQR: 30000,
+  disableSpins: false,
 };

--- a/src/controllers/initializer.ts
+++ b/src/controllers/initializer.ts
@@ -84,7 +84,7 @@ export async function create(
   statusFind?: (statusGet: string) => void,
   options?: CreateConfig
 ) {
-  const spinnies = new Spinnies();
+  const spinnies = new Spinnies({ disableSpins: options.disableSpins });
 
   console.log(`\n
 ▗▄ ▄ ▄  ▄▄▄ ▄   ▄▄▄  ▗▄▄▖▗▄▖ ▗▄▖▄▄▄▖                           
@@ -216,8 +216,8 @@ function checkVenomVersion(spinnies) {
  */
 function logUpdateAvailable(current: string, latest: string) {
   // prettier-ignore
-  const newVersionLog = 
-  `There is a new version of ${chalk.bold(`Venom`)} ${chalk.gray(current)} ➜  ${chalk.bold.green(latest)}\n` + 
+  const newVersionLog =
+  `There is a new version of ${chalk.bold(`Venom`)} ${chalk.gray(current)} ➜  ${chalk.bold.green(latest)}\n` +
   `Update your package by running:\n\n` +
   `${chalk.bold('\>')} ${chalk.blueBright('npm update @s2click/venom')}`;
 


### PR DESCRIPTION
option to pass, on session create, to disable spinnies
animation.
spinnies are fun, spinnies on docker and kubernetes aren't,
since it may log many lines or bug the visualizer.

this option is
default false (which keeps spinnies animations normally), if passed
disableSpins = true, it will disable the spinnies animation.