### PR TITLE
Installing Venom without a new copy of Chromium

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ Thank you for understanding.
 > npm i --save venom-bot
 ```
 
+However, this will install a fresh copy chromium with it (Approx. 150MB). To avoid this - 
+
+```bash
+>npm i --save --ignore-scripts venom-bot
+```
+
 ## Getting started
 
 ```javascript


### PR DESCRIPTION
Ignores scripts by puppeteer which resulted in installing chromium.

I tested it out and couldn't