### PR TITLE
Add option to install without a new copy of Chromium

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ Thank you for understanding.
 > npm i --save venom-bot
 ```
 
+However, this will also install a fresh copy chromium with it (Approx. 150MB). To avoid this - 
+
+```bash
+>npm i --save --ignore-scripts venom-bot
+```
+
 ## Getting started
 
 ```javascript

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "release": "release-it",
     "start": "npm run build:venom & tsc app.ts && node app.js",
     "test": "echo \"No tests yet\"",
-    "watch": "concurrently \"tsc -w\" \"nodemon dist/index.js\""
+    "watch": "concurrently \"tsc -w\" \"nodemon dist/index.js\"",
+    "postinstall": "npm rebuild sharp"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Puppeteer installs a new copy of chromium. To avoid this, we simply have to add ```--ignore-scripts``` tag, but it caused something in sharp module. So I added a postinstall script that will rebuild sharp when venom is installed.