### PR TITLE
fix: Fixed downloadMedia for videos on Chromium (close #456)

### DIFF
--- a/src/lib/wapi/functions/download-media.js
+++ b/src/lib/wapi/functions/download-media.js
@@ -82,6 +82,13 @@ export async function downloadMedia(messageId) {
     blob = Store.BlobCache.get(msg.mediaData.filehash);
   }
 
+  // Transform a VIDEO message to a DOCUMENT message
+  if (!blob && msg.mediaObject.type && msg.mediaObject.type === 'VIDEO') {
+    delete msg.mediaObject.type;
+    msg.type = 'document';
+    return downloadMedia(messageId);
+  }
+
   if (!blob) {
     throw {
       error: true,


### PR DESCRIPTION
Fixes #456.

## Changes proposed in this pull request

- Fixed downloadMedia for videos on Chromium

To test (it takes a while): `npm install github:edgardmessias/venom#fix_download_media_chromium`
