### PR TITLE
docs: add a link to WhatsApp HTTP API project

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@
 
 Documentation at https://orkestral.github.io/venom/index.html
 
+> If you are looking for **WhatsApp HTTP API** you should look at https://github.com/allburov/whatsapp-http-api. It's a HTTP wrapper on top of Venom project with prepared docker image.
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
Fixes #488

## Changes proposed in this pull request

- Add a link to WhatsApp HTTP API project