### PR TITLE
fix: client url undefined

### DIFF
--- a/src/api/model/message.ts
+++ b/src/api/model/message.ts
@@ -69,6 +69,7 @@ export interface Message {
   recvFresh: boolean;
   interactiveAnnotations: any[];
   clientUrl: string;
+  deprecatedMms3Url: string;
   directPath: string;
   mimetype: string;
   filehash: string;

--- a/src/api/whatsapp.ts
+++ b/src/api/whatsapp.ts
@@ -168,10 +168,14 @@ export class Whatsapp extends ControlsLayer {
    */
   public async decryptFile(message: Message) {
     const options = makeOptions(useragentOverride);
-    if (!message.clientUrl)
+    const clientUrl =
+      message.clientUrl !== undefined
+        ? message.clientUrl
+        : message.deprecatedMms3Url;
+    if (!clientUrl)
       throw new Error(
         'message is missing critical data needed to download the file.'
-      );
+      );	  
     let haventGottenImageYet = true;
     let res: any;
     try {

--- a/src/api/whatsapp.ts
+++ b/src/api/whatsapp.ts
@@ -175,7 +175,7 @@ export class Whatsapp extends ControlsLayer {
     if (!clientUrl)
       throw new Error(
         'message is missing critical data needed to download the file.'
-      );	  
+      );
     let haventGottenImageYet = true;
     let res: any;
     try {


### PR DESCRIPTION
Fixes #572.

## Changes proposed in this pull request
- when the value is null in the clienteUrl field it is possible to recover the value in the field deprecatedMms3Url

To test (it takes a while): npm install github:elciorodrigo/venom#issue572
