### PR TITLE
Fix authenticated status check when error

### DIFF
--- a/src/api/layers/host.layer.ts
+++ b/src/api/layers/host.layer.ts
@@ -235,7 +235,7 @@ export class HostLayer {
       if (authenticated === null) {
         this.spin('Failed to authenticate');
         statusFind && statusFind('qrReadFail', this.session);
-      } else if (authenticated) {
+      } else if (authenticated === true) {
         this.spin('QRCode Success');
         statusFind && statusFind('qrReadSuccess', this.session);
       } else {


### PR DESCRIPTION
After calling the autoclose within the condition autheticated false the function isAuthenticated returns object with error http but enters the condition of QRCode Success because the condition is not checking if it is only equals true

After changing condition the status is seted correctelly on error or on success in reading QR Code
