### PR TITLE
Update check-send-exist.js

### DIFF
--- a/src/lib/wapi/functions/check-send-exist.js
+++ b/src/lib/wapi/functions/check-send-exist.js
@@ -141,7 +141,7 @@ export async function sendExist(chatId, returnChat = true, Send = true) {
 
   let ck = await window.WAPI.checkNumberStatus(chatId);
 
-  if (ck.status === 404 && !chatId.includes("@g")) {
+  if (ck.status === 404 && !ck.id._serialized.includes("@g")) {
     return WAPI.scope(chatId, true, ck.status, 'The number does not exist');
   }
   let chat = await window.WAPI.getChat(ck.id._serialized);

--- a/src/lib/wapi/functions/check-send-exist.js
+++ b/src/lib/wapi/functions/check-send-exist.js
@@ -141,7 +141,7 @@ export async function sendExist(chatId, returnChat = true, Send = true) {
 
   let ck = await window.WAPI.checkNumberStatus(chatId);
 
-  if (ck.status === 404) {
+  if (ck.status === 404 && !chatId.includes("@g")) {
     return WAPI.scope(chatId, true, ck.status, 'The number does not exist');
   }
   let chat = await window.WAPI.getChat(ck.id._serialized);


### PR DESCRIPTION

Fixes #1168.

## Changes proposed in this pull request
- Now group messages do not throw the error "The number does not exist"

To test (it takes a while): `npm install github:<username>/venom#<branch>`
