### PR TITLE
Add text option to the message with thumb method

### DIFF
--- a/src/api/layers/sender.layer.ts
+++ b/src/api/layers/sender.layer.ts
@@ -438,6 +438,7 @@ export class SenderLayer extends ListenerLayer {
    * @param url
    * @param title
    * @param description
+   * @param text
    * @param chatId
    */
   public async sendMessageWithThumb(
@@ -445,17 +446,19 @@ export class SenderLayer extends ListenerLayer {
     url: string,
     title: string,
     description: string,
+    text: string,
     chatId: string
   ) {
     return this.page.evaluate(
-      ({ thumb, url, title, description, chatId }) => {
-        WAPI.sendMessageWithThumb(thumb, url, title, description, chatId);
+      ({ thumb, url, title, description, chatId, text }) => {
+        WAPI.sendMessageWithThumb(thumb, url, title, description, text, chatId);
       },
       {
         thumb,
         url,
         title,
         description,
+        text,
         chatId
       }
     );

--- a/src/lib/wapi/functions/send-message-with-thumb.js
+++ b/src/lib/wapi/functions/send-message-with-thumb.js
@@ -57,6 +57,7 @@ export function sendMessageWithThumb(
   url,
   title,
   description,
+  text,
   chatId,
   done
 ) {
@@ -72,7 +73,7 @@ export function sendMessageWithThumb(
     title: title,
     thumbnail: thumb
   };
-  chatSend.sendMessage(url, {
+  chatSend.sendMessage(text, {
     linkPreview: linkPreview,
     mentionedJidList: [],
     quotedMsg: null,

--- a/src/types/WAPI.d.ts
+++ b/src/types/WAPI.d.ts
@@ -238,6 +238,7 @@ interface WAPI {
     url: string,
     title: string,
     description: string,
+    text: string,
     chatId: string
   ) => void;
   sendMute: (id: string, time: number, type: string) => Promise<object>;


### PR DESCRIPTION
## Changes proposed in this pull request

- Allow passing a text body when sending a link preview (sendMessageWithThumb)

The text must contain the referred URL for it to work.

To test (it takes a while): `npm install github:brunohcastro/venom#feat/message-with-thumb-text`
