### PR TITLE
Update whatsapp version to 2.2208.7. 'Wid' for chat check on sendExist

### DIFF
--- a/src/lib/wapi/functions/check-send-exist.js
+++ b/src/lib/wapi/functions/check-send-exist.js
@@ -162,13 +162,15 @@ export async function sendExist(chatId, returnChat = true, Send = true) {
     return WAPI.scope(chatId, true, ck.status, 'The number does not exist');
   }
 
+  const chatWid = new Store.WidFactory.createWid(chatWid);
+
   let chat =
     ck && ck.id && ck.id._serialized
       ? await window.WAPI.getChat(ck.id._serialized)
       : undefined;
 
   if (ck.numberExists && chat === undefined) {
-    var idUser = new window.Store.UserConstructor(chatId, {
+    var idUser = new window.Store.UserConstructor(chatWid, {
       intentionallyUsePrivateConstructor: true
     });
     chat = await Store.Chat.find(idUser);

--- a/src/lib/wapi/functions/check-send-exist.js
+++ b/src/lib/wapi/functions/check-send-exist.js
@@ -170,14 +170,14 @@ export async function sendExist(chatId, returnChat = true, Send = true) {
       : undefined;
 
   if (ck.numberExists && chat === undefined) {
-    var idUser = new window.Store.UserConstructor(chatWid, {
+    var idUser = new window.Store.UserConstructor(chatId, {
       intentionallyUsePrivateConstructor: true
     });
     chat = await Store.Chat.find(idUser);
   }
 
   if (!chat) {
-    const storeChat = await window.Store.Chat.find(chatId);
+    const storeChat = await window.Store.Chat.find(chatWid);
     if (storeChat) {
       chat =
         storeChat && storeChat.id && storeChat.id._serialized


### PR DESCRIPTION
Fixes # .
Fixed the chatid to Wid of the chat room when check some store infos on sendExist.
This will fix, for example, send message on new version of Whatsapp.

To test (it takes a while): `npm install github:lucawen/venom#hotfix/update_wpp_version
