### PR TITLE
'Wid' for GroupMetadata

### DIFF
--- a/src/lib/wapi/functions/get-group-metadata.js
+++ b/src/lib/wapi/functions/get-group-metadata.js
@@ -53,7 +53,8 @@ MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMNNNNMMNNNMMMMMMMMMMMMMMMMM
 MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
 */
 export async function getGroupMetadata(id, done) {
-  let output = window.Store.GroupMetadata.default.find(id);
+  let groupWid = await window.Store.WidFactory.createWid(id);
+  let output = await window.Store.GroupMetadata.default.find(groupWid);
   if (done !== undefined) done(output);
   return output;
 }


### PR DESCRIPTION
Update whatsapp version to 2.2208.7. 'Wid' for groupMetaData to avoid "Uncaught Error: GROUP_JID: invalid jid type: Not an instance of WID" in Whatsapp Multi Device

Fixes # .

## Changes proposed in this pull request

-
-

To test (it takes a while): `npm install github:<username>/venom#<branch>`
