### PR TITLE
Update WAPI Store Cmd

### DIFF
--- a/src/lib/wapi/functions/check-beta.js
+++ b/src/lib/wapi/functions/check-beta.js
@@ -1,4 +1,4 @@
-export async function isBeta() {
+export function isBeta() {
   if (
     !window.localStorage.getItem('WASecretBundle') &&
     !window.localStorage.getItem('WAToken1') &&

--- a/src/lib/wapi/functions/open-chat.js
+++ b/src/lib/wapi/functions/open-chat.js
@@ -54,7 +54,7 @@ MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
 */
 export async function openChat(chatId) {
   const chat = Store.Chat.get(chatId);
-  const result = Store.Cmd.default.openChatBottom(chat);
+  const result = Store.Cmd.openChatBottom(chat);
   return result;
 }
 
@@ -73,6 +73,6 @@ export async function openChatAt(chatId, messageId) {
     msg: atMessage,
     isUnreadDivider: false
   };
-  const result = await Store.Cmd.default._openChat(chat, args);
+  const result = await Store.Cmd._openChat(chat, args);
   return result;
 }

--- a/src/lib/wapi/store/store-objects.js
+++ b/src/lib/wapi/store/store-objects.js
@@ -331,7 +331,7 @@ export const storeObjects = [
   {
     id: 'Cmd',
     conditions: (module) =>
-      module.default && module.default.openChatFromUnread ? module : null
+      module.Cmd && module.Cmd.openChatFromUnread ? module.Cmd : null
   },
   {
     id: 'ReadSeen',


### PR DESCRIPTION
## Changes proposed in this pull request

- Remove `async` from `isBeta`:
  - The function does not call `await`, and is called assuming that it does not return a promise.
  - Also, the [type definition](https://github.com/orkestral/venom/blob/0a204796998d547da7a3395dcf1985a05edf0935/src/types/WAPI.d.ts#L111) shows it only returning a boolean.
- Remove `default` from the `Cmd` store module:
  - The module is defined as a `class` directly under the `Cmd` attribute in recent WhatsApp Web js files
    - Module `88102` on [bootstrap_qr.8c19f3b9920c01c16ec8](https://web.whatsapp.com/bootstrap_qr.8c19f3b9920c01c16ec8.js)

To test (it takes a while): `npm install github:matheusb-comp/venom#fix-wapi`
