### PR TITLE
Fix sendMessage function throw exception on invalid object

### DIFF
--- a/src/lib/wapi/functions/check-send-exist.js
+++ b/src/lib/wapi/functions/check-send-exist.js
@@ -162,7 +162,7 @@ export async function sendExist(chatId, returnChat = true, Send = true) {
     return WAPI.scope(chatId, true, ck.status, 'The number does not exist');
   }
 
-  const chatWid = new Store.WidFactory.createWid(chatWid);
+  const chatWid = new Store.WidFactory.createWid(chatId);
 
   let chat =
     ck && ck.id && ck.id._serialized


### PR DESCRIPTION
To test out this issue: 

1. Build wapi.js (`npm run build:wapi`).
2. Inject the wapi.js script's content into a browser through developer console.
3. Try execute `window.WAPI.sendMessage('phonenumber@c.us', 'test')` in the console.

Reference Error will be returned instead of sending a message.