### PR TITLE
Fix: sendLinkPreview

### DIFF
--- a/src/lib/wapi/functions/send-link-preview.js
+++ b/src/lib/wapi/functions/send-link-preview.js
@@ -90,7 +90,7 @@ export async function sendLinkPreview(chatId, url, text) {
     const message = {
       id: newMsgId,
       ack: 0,
-      body: text,
+      body: text.includes(url) ? text : `${url}\n${text}`,
       from: fromwWid,
       to: chat.id,
       local: !0,

--- a/src/lib/wapi/functions/send-link-preview.js
+++ b/src/lib/wapi/functions/send-link-preview.js
@@ -90,7 +90,7 @@ export async function sendLinkPreview(chatId, url, text) {
     const message = {
       id: newMsgId,
       ack: 0,
-      body: url,
+      body: text,
       from: fromwWid,
       to: chat.id,
       local: !0,
@@ -103,7 +103,7 @@ export async function sendLinkPreview(chatId, url, text) {
       canonicalUrl: url,
       description: url,
       matchedText: url,
-      title: text
+      title: url
     };
     const result = (
       await Promise.all(window.Store.addAndSendMsgToChat(chat, message))


### PR DESCRIPTION
The function sendLinkPreview was sending the Text message as the Title of the preview, it should be the Body of the message