### PR TITLE
fix(wapi): sendFile function throw "Cannot read properties of undefined (reading '0')" exception. Issue #1718.

### DIFF
--- a/src/lib/wapi/functions/send-file.js
+++ b/src/lib/wapi/functions/send-file.js
@@ -73,7 +73,7 @@ export async function sendFile(imgBase64, chatid, filename, caption, type) {
   if (!chat.erro) {
     var mediaBlob = base64ToFile(imgBase64, filename),
       mediaCollection = await processFiles(chat, mediaBlob),
-      media = mediaCollection.models[0];
+      media = mediaCollection._models[0];
 
     var result = (await media.sendToChat(chat, { caption: caption })) || '';
     var m = { type: type, filename: filename, text: caption, mimeType: mime },


### PR DESCRIPTION
# Fix issue 1718

To reproduce the issue, use sendImage or sendFile function to send a file to a WhatsApp contact, the exception will be thrown on accessing the model from mediaCollection.