### PR TITLE
Fix TypeScript definitions for sendButtons

### DIFF
--- a/src/api/layers/sender.layer.ts
+++ b/src/api/layers/sender.layer.ts
@@ -330,7 +330,7 @@ export class SenderLayer extends ListenerLayer {
   public async sendButtons(
     to: string,
     title: string,
-    buttons: [],
+    buttons: { "buttonText": { "displayText": string } }[],
     subtitle: string
   ): Promise<object> {
     return new Promise(async (resolve, reject) => {


### PR DESCRIPTION
## Fixes
The `buttons` paramater in `sendButtons` has the type of `[]` which prevents anyone using typescript with this library from adding buttons to their message, this pull request fixes that.
## Changes proposed in this pull request

- Changes `[]` type on the `sendButtons()` function in `sender.layer.ts` to:
```ts
{
  "buttonText": {
    "displayText": string
  }
}[]
```
To test (it takes a while): `npm install github:nicejs-is-cool/venom#fix-ts-defs`
