### PR TITLE
fix: alterado ordem de inicialização

### DIFF
--- a/src/controllers/initializer.ts
+++ b/src/controllers/initializer.ts
@@ -66,7 +66,12 @@ import { tokenSession } from '../config/tokenSession.config';
 import { checkFileJson } from '../api/helpers/check-token-file';
 import { SocketState, SocketStream } from '../api/model/enum';
 import { SessionTokenCkeck, saveToken, isBeta } from './auth';
-import { initWhatsapp, initBrowser, injectApi } from './browser';
+import {
+  initWhatsapp,
+  initBrowser,
+  injectApi,
+  getWhatsappPage
+} from './browser';
 import { welcomeScreen } from './welcome';
 const path = require('path');
 /**
@@ -249,6 +254,8 @@ export async function create(
 
     statusFind && statusFind('initWhatsapp', this.session);
     // Initialize whatsapp
+    const newPage: Page = await getWhatsappPage(browser);
+    const client = new Whatsapp(newPage, session, mergedOptions);
     const page: false | Page = await initWhatsapp(
       session,
       mergedOptions,
@@ -273,8 +280,6 @@ export async function create(
     logger.info(`${chalk.green('Page successfully accessed')}`, {
       session
     });
-
-    const client = new Whatsapp(page, session, mergedOptions);
 
     client.onStreamChange(async (stateStream) => {
       if (stateStream === SocketStream.CONNECTED) {


### PR DESCRIPTION
Fixes #1889.

Alterado a ordem de iniciar a classe Whatsapp para o load vir antes de navegar na pagina do WPP