### PR TITLE
Context fix for session variable

### DIFF
--- a/src/controllers/initializer.ts
+++ b/src/controllers/initializer.ts
@@ -175,7 +175,7 @@ export async function create(
 
   logger.info(`${chalk.underline('https://orkestral.io - official site!')}\n`);
 
-  statusFind && statusFind('initBrowser', this.session);
+  statusFind && statusFind('initBrowser', session);
 
   // Initialize whatsapp
   if (mergedOptions.browserWS) {
@@ -190,7 +190,7 @@ export async function create(
     logger.info('Error when try to connect ' + mergedOptions.browserWS, {
       session
     });
-    statusFind && statusFind('serverWssNotConnected', this.session);
+    statusFind && statusFind('serverWssNotConnected', session);
     throw `Error when try to connect ${mergedOptions.browserWS}`;
   }
 
@@ -199,7 +199,7 @@ export async function create(
     logger.info('Error no open browser.... ', {
       session
     });
-    statusFind && statusFind('noOpenBrowser', this.session);
+    statusFind && statusFind('noOpenBrowser', session);
     throw `Error no open browser....`;
   }
 
@@ -207,9 +207,9 @@ export async function create(
     logger.info('Has been properly connected to the wss server', {
       session
     });
-    statusFind && statusFind('connectBrowserWs', this.session);
+    statusFind && statusFind('connectBrowserWs', session);
   } else {
-    statusFind && statusFind('openBrowser', this.session);
+    statusFind && statusFind('openBrowser', session);
     logger.info('Browser successfully opened', {
       session
     });
@@ -252,7 +252,7 @@ export async function create(
       session
     });
 
-    statusFind && statusFind('initWhatsapp', this.session);
+    statusFind && statusFind('initWhatsapp', session);
 
     const newPage: Page = await getWhatsappPage(browser);
     const client = new Whatsapp(newPage, session, mergedOptions);
@@ -272,11 +272,11 @@ export async function create(
         session
       });
 
-      statusFind && statusFind('erroPageWhatsapp', this.session);
+      statusFind && statusFind('erroPageWhatsapp', session);
       throw 'Error when trying to access the page: "https://web.whatsapp.com"';
     }
 
-    statusFind && statusFind('successPageWhatsapp', this.session);
+    statusFind && statusFind('successPageWhatsapp', session);
     logger.info(`${chalk.green('Page successfully accessed')}`, {
       session
     });
@@ -358,7 +358,7 @@ export async function create(
         console.log(`\nDebug: Option waitForLogin it's true. waiting...`);
       }
 
-      statusFind && statusFind('waitForLogin', this.session);
+      statusFind && statusFind('waitForLogin', session);
 
       const isLogged = await client.waitForLogin(catchQR, statusFind);
 
@@ -403,7 +403,7 @@ export async function create(
       );
     }
 
-    statusFind && statusFind('waitChat', this.session);
+    statusFind && statusFind('waitChat', session);
 
     await page.waitForSelector('#app .two', { visible: true }).catch(() => {});
 
@@ -449,7 +449,7 @@ export async function create(
     if (mergedOptions.debug) {
       console.log(`\nDebug: injecting Api done...`);
     }
-    statusFind && statusFind('successChat', this.session);
+    statusFind && statusFind('successChat', session);
     return client;
   }
 }


### PR DESCRIPTION
The "session" variable has context only inside the create() function, the use of "this.session" returns "undefined" after the project build.

[pt-br] 
A variável "session" possui contexto somente dentro da function create(), o uso do "this.session" retorna "undefined" após o build do projeto.