### PR TITLE
Fixing error on sendText

### DIFF
--- a/src/api/layers/sender.layer.ts
+++ b/src/api/layers/sender.layer.ts
@@ -415,11 +415,16 @@ export class SenderLayer extends ListenerLayer {
         },
         { to, content, passId, checkNumber, forcingReturn, delSend }
       );
-      if (result['erro'] == true) {
-        return reject(result);
-      } else {
-        return resolve(result);
-      }
+
+      return resolve(result);
+
+      // Fixing error onde send text
+      
+      // if (result['erro'] == true) {
+      //   return reject(result);
+      // } else {
+      //   return resolve(result);
+      // }
     });
   }
 


### PR DESCRIPTION
Error:
Cannot read properties of undefined (reading 'erro') at /usr/src/node_modules/venom-bot/src/api/layers/sender.layer.ts:418:17

Fixes # .

## Changes proposed in this pull request

-
-

To test (it takes a while): `npm install github:<username>/venom#<branch>`
