### PR TITLE
Allow headless mode to be false

### DIFF
--- a/src/controllers/browser.ts
+++ b/src/controllers/browser.ts
@@ -502,7 +502,7 @@ export async function initBrowser(
       } else {
         const browser = await puppeteer.launch({
           executablePath,
-          headless: options.headless === true ? options.headless : 'new',
+          headless: options.headless === true || options.headless === false ? options.headless : 'new',
           args: ['--no-sandbox', '--disable-setuid-sandbox']
         });
 


### PR DESCRIPTION

Fixes #2457 by allowing headless to be false in addition to 'new' or true.
