### PR TITLE
Respect CreateConfig options when using a session name

### DIFF
--- a/src/controllers/initializer.ts
+++ b/src/controllers/initializer.ts
@@ -145,7 +145,7 @@ export async function create(
       sessionOrOption.replace(/\s/g, '').length
     ) {
       session = sessionOrOption.replace(/\s/g, '');
-      options = { session };
+      options['session'] = session;
     } else if (typeof sessionOrOption === 'object') {
       session = sessionOrOption.session || session;
       catchQR = sessionOrOption.catchQR || catchQR;


### PR DESCRIPTION
Currently, when a session name is passed to the create function, it ignores any options passed to the options parameter.  This patch fixes that.  Part of fixing #2457 

