### PR TITLE
Fix Cannot read properties of undefined (reading 'fromMe')

### DIFF
--- a/src/lib/wapi/functions/process-message-object.js
+++ b/src/lib/wapi/functions/process-message-object.js
@@ -9,7 +9,7 @@ export async function processMessageObj(
     } else {
       return;
     }
-  } else if (messageObj.id.fromMe === false || includeMe) {
+  } else if (messageObj.id?.fromMe === false || includeMe) {
     return await WAPI._serializeMessageObj(messageObj);
   }
   return;


### PR DESCRIPTION
Fixes error when processing msg obj:

<img width="588" alt="Cursor_and_WhatsApp_🔊" src="https://github.com/orkestral/venom/assets/2242549/fcbbcd29-3b65-4f7a-abec-6e2a7498db8e">

## Changes proposed in this pull request

- Fix a simple bug that occurs when `messageObj` is not a object
<img width="544" alt="Cursor_and__1__WhatsApp" src="https://github.com/orkestral/venom/assets/2242549/565bda9c-cfa7-4263-a32b-973245a92d07">


To test (it takes a while): `npm install github:<username>/venom#<branch>`
