### PR TITLE
feat: message body option to sendLinkPreview

### DIFF
--- a/src/api/layers/sender.layer.ts
+++ b/src/api/layers/sender.layer.ts
@@ -432,7 +432,8 @@ export class SenderLayer extends ListenerLayer {
   public async sendLinkPreview(
     chatId: string,
     url: string,
-    title: string
+    title: string,
+    message: string,
   ): Promise<object> {
     return new Promise(async (resolve, reject) => {
       const typeFunction = 'sendLinkPreview';
@@ -458,6 +459,13 @@ export class SenderLayer extends ListenerLayer {
           value: title,
           function: typeFunction,
           isUser: false
+        },
+        {
+          param: 'message',
+          type: type,
+          value: message,
+          function: typeFunction,
+          isUser: false
         }
       ];
       const validating = checkValuesSender(check);
@@ -467,9 +475,9 @@ export class SenderLayer extends ListenerLayer {
       const thumbnail = await dowloadMetaFileBase64(url);
       const result = await this.page.evaluate(
         ({ chatId, url, title, thumbnail }) => {
-          return WAPI.sendLinkPreview(chatId, url, title, thumbnail);
+          return WAPI.sendLinkPreview(chatId, url, title, message, thumbnail);
         },
-        { chatId, url, title, thumbnail }
+        { chatId, url, title, message, thumbnail }
       );
       if (result['erro'] == true) {
         return reject(result);

--- a/src/api/layers/sender.layer.ts
+++ b/src/api/layers/sender.layer.ts
@@ -474,7 +474,7 @@ export class SenderLayer extends ListenerLayer {
       }
       const thumbnail = await dowloadMetaFileBase64(url);
       const result = await this.page.evaluate(
-        ({ chatId, url, title, thumbnail }) => {
+        ({ chatId, url, title, message, thumbnail }) => {
           return WAPI.sendLinkPreview(chatId, url, title, message, thumbnail);
         },
         { chatId, url, title, message, thumbnail }

--- a/src/lib/wapi/functions/send-link-preview.js
+++ b/src/lib/wapi/functions/send-link-preview.js
@@ -1,4 +1,4 @@
-export async function sendLinkPreview(chatId, url, text, thumbnail) {
+export async function sendLinkPreview(chatId, url, text, body, thumbnail) {
   text = text || '';
   const _Path = {
     Protocol: '^(https?:\\/\\/)?',
@@ -39,7 +39,7 @@ export async function sendLinkPreview(chatId, url, text, thumbnail) {
       id: newMsgId,
       links: link,
       ack: 0,
-      body: url,
+      body: body.includes(url) ? body : url + "\n" + body,
       from: fromwWid,
       to: chat.id,
       local: !0,

--- a/src/types/WAPI.d.ts
+++ b/src/types/WAPI.d.ts
@@ -164,6 +164,7 @@ interface WAPI {
     chatId: string,
     url: string,
     title: string,
+    message: string,
     thumbnail: string
   ) => Promise<SendLinkResult>;
   sendLocation: (


### PR DESCRIPTION
`sendLinkPreview` option to send a body message along with the URL and its preview title.

![image](https://github.com/orkestral/venom/assets/95389123/398d8c22-e3d7-4cfe-b334-ca576357f317)
For reference: in the above image, the body message would be:

https://github.com/
Hello