### PR TITLE
#2582  updated the copyright year and copyright owner in the license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright [2022] [Orkestral]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [2022] [Orkestral]
+   Copyright 2022 Orkestral
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fixes # .

## Changes proposed in this pull request

-  I have changed the copyright year in the license to the "Start year of company"
-  I have changed the copyright owner to the owner name "mentioned in the company website"

![image](https://github.com/orkestral/venom/assets/89439095/f92b2267-c9d3-4d90-ac97-772dbacb8ab0)

To test (it takes a while): `npm install github:gyanavardhana/venom#master`

## Please mention if any changes needed I am willing to contribute.
