### PR TITLE
Force webpack

### DIFF
--- a/src/config/create-config.ts
+++ b/src/config/create-config.ts
@@ -127,6 +127,11 @@ export interface CreateConfig {
    * @default null
    */
   browserPathExecutable?: string;
+  /**
+   * Force webpack version of WhatsApp.
+   * @default false
+   */
+  forceWebpack?: boolean;
 }
 
 export const defaultOptions: CreateConfig = {
@@ -151,5 +156,6 @@ export const defaultOptions: CreateConfig = {
   attemptsForceConnectLoad: 5,
   forceConnectTime: 5000,
   addProxy: [],
-  browserPathExecutable: null
+  browserPathExecutable: null,
+  forceWebpack: false
 };

--- a/src/config/options.ts
+++ b/src/config/options.ts
@@ -93,6 +93,11 @@ export interface options {
    * @default null
    */
   browserPathExecutable?: string;
+  /**
+   * Force webpack version of WhatsApp.
+   * @default false
+   */
+  forceWebpack?: boolean;
 }
 
 export const defaultOptions: options = {
@@ -110,5 +115,6 @@ export const defaultOptions: options = {
   addBrowserArgs: [],
   autoClose: 120000,
   addProxy: [],
-  browserPathExecutable: ''
+  browserPathExecutable: '',
+  forceWebpack: false
 };

--- a/src/controllers/browser.ts
+++ b/src/controllers/browser.ts
@@ -50,26 +50,26 @@ export async function initWhatsapp(
     await waPage.setUserAgent(useragentOverride);
     waPage.setDefaultTimeout(60000);
 
-    const { userPass, userProxy, addProxy, forceWebpack } = options;
+    const { userPass, userProxy, addProxy } = options;
 
-    if(forceWebpack === true)
-    {
+    if (options.forceWebpack === true) {
       await waPage.setRequestInterception(true);
-      page.on('request', request => {
-          // Modify the request headers
-          const headers = request.headers();
-          if (headers.cookie) {
-            // Filter out the 'wa_build' cookies and reconstruct the cookie header
-            headers.cookie = headers.cookie.split(';')
-              .filter(cookie => !cookie.trim().startsWith('wa_build'))
-              .join(';');
-          }
-  
-          // Continue the request with potentially modified headers
-          request.continue({headers});
-       });
+      waPage.on('request', (request) => {
+        // Modify the request headers
+        const headers = request.headers();
+        if (headers.cookie) {
+          // Filter out the 'wa_build' cookies and reconstruct the cookie header
+          headers.cookie = headers.cookie
+            .split(';')
+            .filter((cookie) => !cookie.trim().startsWith('wa_build'))
+            .join(';');
+        }
+
+        // Continue the request with potentially modified headers
+        request.continue({ headers });
+      });
     }
-    
+
     if (
       typeof userPass === 'string' &&
       userPass.length &&

--- a/src/controllers/browser.ts
+++ b/src/controllers/browser.ts
@@ -50,8 +50,26 @@ export async function initWhatsapp(
     await waPage.setUserAgent(useragentOverride);
     waPage.setDefaultTimeout(60000);
 
-    const { userPass, userProxy, addProxy } = options;
+    const { userPass, userProxy, addProxy, forceWebpack } = options;
 
+    if(forceWebpack === true)
+    {
+      await waPage.setRequestInterception(true);
+      page.on('request', request => {
+          // Modify the request headers
+          const headers = request.headers();
+          if (headers.cookie) {
+            // Filter out the 'wa_build' cookies and reconstruct the cookie header
+            headers.cookie = headers.cookie.split(';')
+              .filter(cookie => !cookie.trim().startsWith('wa_build'))
+              .join(';');
+          }
+  
+          // Continue the request with potentially modified headers
+          request.continue({headers});
+       });
+    }
+    
     if (
       typeof userPass === 'string' &&
       userPass.length &&


### PR DESCRIPTION
Fixes #2631
Fixes #2622

## Changes proposed in this pull request

Add a configuration parameter to force webpack version of WhatsApp by dropping the wa_build cookie.

To test (it takes a while): `npm install github:9cb14c2ec0/venom#force_webpack`
