### PR TITLE
Fix ERR_REQUIRE_ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "boxen": "^5.1.1",
     "chalk": "^4.0.0",
     "cheerio": "^1.0.0-rc.12",
-    "chrome-launcher": "^1.1.0",
+    "chrome-launcher": "0.15.2",
     "chrome-version": "^1.0.1",
     "dotenv": "^16.0.1",
     "esm": "^3.2.25",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "esm": "^3.2.25",
     "futoin-hkdf": "^1.5.3",
     "i": "^0.3.7",
-    "is-root": "^3.0.0",
+    "is-root": "2.1.0",
     "latest-lib": "^0.2.1",
     "mime-types": "^2.1.35",
     "npm-check-updates": "^16.14.12",


### PR DESCRIPTION
Fixes #2571 .

## Changes proposed in this pull request

- Since venom is not an ESM module, it can't import dependencies that have converted to ESM format.  So we pin the versions of chrome-launcher and is-root to non-ESM versions

To test (it takes a while): `npm install github:9cb14c1ec0/venom#non-esm`
