### PR TITLE
Add versioning capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1046,6 +1046,21 @@ Use "autoClose: 0 | false" to disable auto closing.
 
 ### Debugging
 
+### WhatsApp Web Versions
+
+You can use cached versions of WhatsApp Web by passing the `webVersion` arguments as part of your venom options:
+```javascript
+venom.create({
+    session: 'sessionname', //name of session
+    headless: false,
+    logQR: true,
+    webVersion: '2.2402.5'
+  })
+  .then((client) => {
+    start(client);
+  });
+```
+This feature can use any version available in the list at https://github.com/wppconnect-team/wa-version/tree/main/html
 ## Development
 
 Building venom is really simple altough it contains 3 main projects inside

--- a/src/config/create-config.ts
+++ b/src/config/create-config.ts
@@ -132,6 +132,11 @@ export interface CreateConfig {
    * @default false
    */
   forceWebpack?: boolean;
+  /**
+   * Use a cached version of WhatsApp
+   * @default false
+   */
+  webVersion?: boolean | string;
 }
 
 export const defaultOptions: CreateConfig = {
@@ -157,5 +162,6 @@ export const defaultOptions: CreateConfig = {
   forceConnectTime: 5000,
   addProxy: [],
   browserPathExecutable: null,
-  forceWebpack: false
+  forceWebpack: false,
+  webVersion: false
 };

--- a/src/config/options.ts
+++ b/src/config/options.ts
@@ -98,6 +98,11 @@ export interface options {
    * @default false
    */
   forceWebpack?: boolean;
+  /**
+   * Use a cached version of WhatsApp
+   * @default false
+   */
+  webVersion?: boolean | string;
 }
 
 export const defaultOptions: options = {
@@ -116,5 +121,6 @@ export const defaultOptions: options = {
   autoClose: 120000,
   addProxy: [],
   browserPathExecutable: '',
-  forceWebpack: false
+  forceWebpack: false,
+  webVersion: false
 };

--- a/test/index.js
+++ b/test/index.js
@@ -3,15 +3,18 @@ const venom = require('../dist');
 
 
 venom.create({
-  session: 'sessionname', //name of session
-  headless: false,
-  logQR: true,
-}).then((client)=> {
-  start(client);
-});
+    session: 'sessionname', //name of session
+    headless: false,
+    logQR: true,
+    webVersion: '2.2402.5'
+  })
+  .then((client) => {
+    start(client);
+  });
 
 async function start(client) {
   const f = await client.getHostDevice();
+  console.log(await client.getWAVersion());
   console.log(f);
   // client.onMessage((message) => {
   //   console.log(message);


### PR DESCRIPTION
Every time WhatsApp pushes an update to their web app, it is a scramble for project like venom to adapt.  Fortunately, the [wa-version](https://github.com/wppconnect-team/wa-version) repository keeps copies of stable versions of WhatsApp.  We can inject these versions into the browser, and maintain a sense of stability while adapting to changes.

To test (it takes a while): `npm install github:9cb14c1ec0/venom#versioning`
