### PR TITLE
initial attempt to update module loading

### DIFF
--- a/src/api/whatsapp.ts
+++ b/src/api/whatsapp.ts
@@ -28,10 +28,15 @@ export class Whatsapp extends ControlsLayer {
 
   async initService() {
     try {
-      await this.page
-        .waitForFunction('webpackChunkwhatsapp_web_client.length')
-        .catch();
-
+      if (this.options.forceWebpack === false) {
+        await this.page.evaluate(() => {
+          window['__debug'] = eval("require('__debug');");
+        });
+      } else {
+        await this.page
+          .waitForFunction('webpackChunkwhatsapp_web_client.length')
+          .catch();
+      }
       await this.page
         .addScriptTag({
           path: require.resolve(path.join(__dirname, '../lib/wapi/', 'wapi.js'))

--- a/src/controllers/browser.ts
+++ b/src/controllers/browser.ts
@@ -59,7 +59,6 @@ export async function initWhatsapp(
     if (typeof options.webVersion === 'string' && options.webVersion.length) {
       await waPage.setRequestInterception(true);
       waPage.on('request', async (req) => {
-        fs.appendFileSync('log.txt', req.url() + '\n');
         if (req.url() === 'https://web.whatsapp.com/') {
           let url = cach_url + options.webVersion + '.html';
 

--- a/src/lib/wapi/api.js
+++ b/src/lib/wapi/api.js
@@ -45,21 +45,27 @@ import {
 
 //initialized scrap webpack
 (async () => {
-  window[injectConfig.webpack] = window[injectConfig.webpack] || [];
   window.Store = {};
-  while (true) {
-    try {
-      const webPackLast = window[injectConfig.webpack].length - 1;
-      if (
-        !window[injectConfig.webpack][webPackLast][0].includes(
-          injectConfig.parasite
-        )
-      ) {
-        await injectParasiteSnake();
-        return;
+  if (window.__debug) {
+    await injectParasiteSnake();
+  } else {
+    // old webpack
+    window[injectConfig.webpack] = window[injectConfig.webpack] || [];
+
+    while (true) {
+      try {
+        const webPackLast = window[injectConfig.webpack].length - 1;
+        if (
+          !window[injectConfig.webpack][webPackLast][0].includes(
+            injectConfig.parasite
+          )
+        ) {
+          await injectParasiteSnake();
+          return;
+        }
+      } catch {
+        await sleep(1000);
       }
-    } catch {
-      await sleep(1000);
     }
   }
 })();

--- a/src/lib/wapi/functions/add-chat-wapi.js
+++ b/src/lib/wapi/functions/add-chat-wapi.js
@@ -1,29 +1,47 @@
 import { injectConfig, filterModule, filterObjects } from '../helper';
 
 export async function addChatWapi() {
-  window[injectConfig.webpack].push([
-    [injectConfig.parasite],
-    {},
-    async function (o) {
-      let modules = [];
-      for (let idx in o.m) {
-        modules.push(o(idx));
-      }
+  if (window.__debug) {
+    const filterMod = await filterModule(filterObjects, window.getModuleList());
 
-      const filterMod = await filterModule(filterObjects, modules);
-
-      filterMod.forEach((needObj) => {
-        if (needObj.yesModule) {
-          if (!window.Store[needObj.type]) {
-            window.Store[needObj.type] = needObj.yesModule;
-          }
+    filterMod.forEach((needObj) => {
+      if (needObj.yesModule) {
+        if (!window.Store[needObj.type]) {
+          window.Store[needObj.type] = needObj.yesModule;
         }
-      });
-
-      if (Store && Store.BusinessProfile) {
-        Store.Chat._findAndParse = Store.BusinessProfile._findAndParse;
-        Store.Chat._find = Store.BusinessProfile._find;
       }
+    });
+
+    if (Store && Store.BusinessProfile) {
+      Store.Chat._findAndParse = Store.BusinessProfile._findAndParse;
+      Store.Chat._find = Store.BusinessProfile._find;
     }
-  ]);
+  } else {
+    // old webpack
+    window[injectConfig.webpack].push([
+      [injectConfig.parasite],
+      {},
+      async function (o) {
+        let modules = [];
+        for (let idx in o.m) {
+          modules.push(o(idx));
+        }
+
+        const filterMod = await filterModule(filterObjects, modules);
+
+        filterMod.forEach((needObj) => {
+          if (needObj.yesModule) {
+            if (!window.Store[needObj.type]) {
+              window.Store[needObj.type] = needObj.yesModule;
+            }
+          }
+        });
+
+        if (Store && Store.BusinessProfile) {
+          Store.Chat._findAndParse = Store.BusinessProfile._findAndParse;
+          Store.Chat._find = Store.BusinessProfile._find;
+        }
+      }
+    ]);
+  }
 }

--- a/src/lib/wapi/functions/help/add-chat-wapi.js
+++ b/src/lib/wapi/functions/help/add-chat-wapi.js
@@ -2,29 +2,45 @@ import { filterObjects } from './filter-object';
 import { injectConfig, filterModule } from '../../help';
 
 export async function addChatWapi() {
-  window[injectConfig.webpack].push([
-    [injectConfig.parasite],
-    {},
-    async function (o) {
-      let modules = [];
-      for (let idx in o.m) {
-        modules.push(o(idx));
-      }
-
-      const filterMod = await filterModule(filterObjects, modules);
-
-      filterMod.forEach((needObj) => {
-        if (needObj.yesModule) {
-          if (!Store[needObj.type]) {
-            Store[needObj.type] = needObj.yesModule;
-          }
+  if (window.__debug) {
+    const filterMod = await filterModule(filterObjects, window.getModuleList());
+    filterMod.forEach((needObj) => {
+      if (needObj.yesModule) {
+        if (!Store[needObj.type]) {
+          Store[needObj.type] = needObj.yesModule;
         }
-      });
-
-      if (Store && Store.BusinessProfile) {
-        Store.Chat._findAndParse = Store.BusinessProfile._findAndParse;
-        Store.Chat._find = Store.BusinessProfile._find;
       }
+    });
+
+    if (Store && Store.BusinessProfile) {
+      Store.Chat._findAndParse = Store.BusinessProfile._findAndParse;
+      Store.Chat._find = Store.BusinessProfile._find;
     }
-  ]);
+  } else {
+    window[injectConfig.webpack].push([
+      [injectConfig.parasite],
+      {},
+      async function (o) {
+        let modules = [];
+        for (let idx in o.m) {
+          modules.push(o(idx));
+        }
+
+        const filterMod = await filterModule(filterObjects, modules);
+
+        filterMod.forEach((needObj) => {
+          if (needObj.yesModule) {
+            if (!Store[needObj.type]) {
+              Store[needObj.type] = needObj.yesModule;
+            }
+          }
+        });
+
+        if (Store && Store.BusinessProfile) {
+          Store.Chat._findAndParse = Store.BusinessProfile._findAndParse;
+          Store.Chat._find = Store.BusinessProfile._find;
+        }
+      }
+    ]);
+  }
 }

--- a/src/lib/wapi/help/inject-paresite.js
+++ b/src/lib/wapi/help/inject-paresite.js
@@ -1,36 +1,61 @@
 import { injectConfig, filterObjects, filterModule } from './index';
 export const injectParasiteSnake = async () => {
-  window[injectConfig.webpack].push([
-    [injectConfig.parasite],
-    {},
-    async function (e) {
-      const modules = []; // modules whatsapp array
-      Object.keys(e.m).forEach(function (mod) {
-        modules[mod] = e(mod);
-      });
+  if (window.__debug) {
+    const filterMod = await filterModule(filterObjects, window.getModuleList());
+    filterMod.forEach((needObj) => {
+      if (needObj.yesModule) {
+        if (needObj.type !== 'Module') {
+          if (!Store[needObj.type]) {
+            Store[needObj.type] = needObj.yesModule;
+          }
+        }
+      }
+    });
 
-      const filterMod = await filterModule(filterObjects, modules);
+    const module = filterMod.filter((e) => e.type === 'Module')[0].yesModule;
+    Object.keys(module).forEach((key) => {
+      if (!['Chat'].includes(key)) {
+        if (Store[key]) {
+          Store[key + '_'] = module[key];
+        } else {
+          Store[key] = module[key];
+        }
+      }
+    });
+  } else {
+    // old webpack approach
+    window[injectConfig.webpack].push([
+      [injectConfig.parasite],
+      {},
+      async function (e) {
+        const modules = []; // modules whatsapp array
+        Object.keys(e.m).forEach(function (mod) {
+          modules[mod] = e(mod);
+        });
+        const filterMod = await filterModule(filterObjects, modules);
 
-      filterMod.forEach((needObj) => {
-        if (needObj.yesModule) {
-          if (needObj.type !== 'Module') {
-            if (!Store[needObj.type]) {
-              Store[needObj.type] = needObj.yesModule;
+        filterMod.forEach((needObj) => {
+          if (needObj.yesModule) {
+            if (needObj.type !== 'Module') {
+              if (!Store[needObj.type]) {
+                Store[needObj.type] = needObj.yesModule;
+              }
             }
           }
-        }
-      });
+        });
 
-      const module = filterMod.filter((e) => e.type === 'Module')[0].yesModule;
-      Object.keys(module).forEach((key) => {
-        if (!['Chat'].includes(key)) {
-          if (Store[key]) {
-            Store[key + '_'] = module[key];
-          } else {
-            Store[key] = module[key];
+        const module = filterMod.filter((e) => e.type === 'Module')[0]
+          .yesModule;
+        Object.keys(module).forEach((key) => {
+          if (!['Chat'].includes(key)) {
+            if (Store[key]) {
+              Store[key + '_'] = module[key];
+            } else {
+              Store[key] = module[key];
+            }
           }
-        }
-      });
-    }
-  ]);
+        });
+      }
+    ]);
+  }
 };

--- a/src/lib/wapi/store/get-store.js
+++ b/src/lib/wapi/store/get-store.js
@@ -12,9 +12,10 @@ export async function getStore(modules) {
         if (neededModule !== null) {
           foundCount++;
           needObj.foundedModule = neededModule;
+          console.log(neededModule);
         }
       });
-      if (foundCount == neededObjects.length) {
+      if (foundCount === neededObjects.length) {
         break;
       }
     }
@@ -49,29 +50,45 @@ export async function getStore(modules) {
 
   window.mR = async (find) => {
     return new Promise((resolve) => {
-      const parasite = `parasite${Date.now()}`;
-      window["webpackChunkwhatsapp_web_client"].push([
-        [parasite],
-        {},
-        function (o) {
-          let modules = [];
-          for (let idx in o.m) {
-            modules.push(o(idx));
-          }
-          for (let idx in modules) {
-            if (typeof modules[idx] === "object" && modules[idx] !== null) {
-              let module = modules[idx];
+      if (window.__debug) {
+        for (let idx in window.getModuleList()) {
+          if (typeof modules[idx] === "object" && modules[idx] !== null) {
+            let module = modules[idx];
 
-              var evet = module[find] ? module : null;
-              if (evet) {
-                window[find] = evet;
-                return resolve(window[find]);
-              }
+            var evet = module[find] ? module : null;
+            if (evet) {
+              window[find] = evet;
+              return resolve(window[find]);
             }
           }
+        }
+      } else {
+        const parasite = `parasite${Date.now()}`;
+        window["webpackChunkwhatsapp_web_client"].push([
+          [parasite],
+          {},
+          function (o) {
+            let modules = [];
+            for (let idx in o.m) {
+              modules.push(o(idx));
+            }
 
-        },
-      ]);
+            for (let idx in modules) {
+              if (typeof modules[idx] === "object" && modules[idx] !== null) {
+                let module = modules[idx];
+
+                var evet = module[find] ? module : null;
+                if (evet) {
+                  window[find] = evet;
+                  return resolve(window[find]);
+                }
+              }
+            }
+
+          },
+        ]);
+      }
+
     });
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -6,13 +6,14 @@ venom.create({
     session: 'sessionname', //name of session
     headless: false,
     logQR: true,
-    webVersion: '2.2402.5'
+    webVersion: '2.3000.1012170943-alpha'
   })
   .then((client) => {
     start(client);
   });
 
 async function start(client) {
+
   const f = await client.getHostDevice();
   console.log(await client.getWAVersion());
   console.log(f);


### PR DESCRIPTION
Now that WhatsApp has moved off of Webpack, this affects how module loading works in venom.  This draft pull request has an initial implementation to support both Webpack and Comet, depending on the version of WhatsApp a user has.  Not all store objects load with this initial attempt, and if anyone knows how to fix that I would be glad to know.

To test (it takes a while): `npm install github:9cb14c1ec0/venom#new_modules`
