### PR TITLE
Update README to indicate getNumberProfile does not work

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,6 +700,8 @@ const allMessages = await client.loadAndGetAllMessagesInChat(
 const status = await client.getStatus('000000000000@c.us');
 
 // Retrieve user profile
+// Please note that this function does not currently work due to a bug in WhatsApp itself.
+// There is no telling if or when this function might work again.
 const user = await client.getNumberProfile('000000000000@c.us');
 
 // Retrieve all unread message


### PR DESCRIPTION
Fixes #2635

The error encountered when calling getNumberProfile is one triggered by WhatsApp javascript calling a function that does not exist.  Since there is no practical way to patch WhatsApp's javascript, the issue should be closed and the documentation updated to note the problem
