### PR TITLE
window.Store.Cmd.openChatBottom is not defined. Deleting the call it …

### DIFF
--- a/src/lib/wapi/functions/get-group-participant.js
+++ b/src/lib/wapi/functions/get-group-participant.js
@@ -8,8 +8,6 @@ export async function getGroupParticipant(groupId, time = 1000) {
   const chat = await WAPI.sendExist(groupId);
 
   if (chat && chat.status != 404 && chat.id) {
-    await window.Store.Cmd.openChatBottom(chat);
-    await sleep(time);
     const moduleGroup = await window.Store.GroupMetadata._models.filter(
       (e) => e.id._serialized === groupId
     );


### PR DESCRIPTION
…from getGroupParticipant() appears to allow the function to return correct data

Fixes # .
#2536 
#2540 

## Changes proposed in this pull request
window.Store.Cmd.openChatBottom(chat) doesn't seem to be defined anywhere - this has been like this for a while.
Removing the call to it altogether appears to have no adverse affects on getGroupParticipant()

-

To test (it takes a while): `npm install github:ghayman/venom#fix-get-group-participant`
