### PR TITLE
Add sendTextViaTyping function

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,10 @@ await client
     console.error('Error when sending: ', erro); //return object error
   });
 
+
+// Send by injecting keystrokes into WhatsApp, thus maintaining the typing indicator
+await client.sendTextViaTyping('000000000000@c.us', '👋 Hello from venom!');
+
 // Send location
 await client
   .sendLocation('000000000000@c.us', '-13.6561589', '-69.7309264', 'Brasil')

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "5.0.23",
       "license": "MIT",
       "dependencies": {
+        "async-mutex": "^0.5.0",
         "atob": "^2.1.2",
         "axios": "^1.4.0",
         "boxen": "^5.1.1",
@@ -3311,6 +3312,14 @@
           "url": "https://paulmillr.com/funding/"
         }
       ]
+    },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/async-retry": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "webpack-cli": "^5.0.1"
   },
   "dependencies": {
+    "async-mutex": "^0.5.0",
     "atob": "^2.1.2",
     "axios": "^1.4.0",
     "boxen": "^5.1.1",

--- a/src/types/WAPI.d.ts
+++ b/src/types/WAPI.d.ts
@@ -34,6 +34,7 @@ interface WAPI {
     skipMyMessages: boolean
   ) => Promise<object>;
   getAllChats: () => Promise<Chat[] | object[]>;
+  getAllChatIds: () => Promise<string[]>;
   getAllChatsWithMessages: (withNewMessageOnly?: boolean) => Chat[];
   getAllChatsWithNewMsg: () => Chat[];
   getAllContacts: () => Contact[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1519,6 +1519,13 @@ async-each@^1.0.1:
   resolved "https://registry.npmjs.org/async-each/-/async-each-1.0.6.tgz"
   integrity sha512-c646jH1avxr+aVpndVMeAfYw7wAa6idufrlN3LPA4PmKS0QEGp6PIC9nwz0WQkkvBGAMEki3pFdtxaF39J9vvg==
 
+async-mutex@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz"
+  integrity sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==
+  dependencies:
+    tslib "^2.4.0"
+
 async-retry@1.3.3:
   version "1.3.3"
   resolved "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz"
@@ -9166,7 +9173,7 @@ tslib@^1.8.1:
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.1, tslib@^2.1.0, tslib@^2.5.0:
+tslib@^2.0.1, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.5.0:
   version "2.5.3"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz"
   integrity sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==


### PR DESCRIPTION
This function works by injecting keystrokes into the browser page, instead of using javascript hooks.  This maintains the typing indicator properly.

Fixes #2564 

To test (it takes a while): `npm install github:9cb14c1ec0/venom#textviatyping`
