### PR TITLE
Enforce webpack on versions less than 2.3 when no options are set

### DIFF
--- a/src/api/whatsapp.ts
+++ b/src/api/whatsapp.ts
@@ -28,7 +28,25 @@ export class Whatsapp extends ControlsLayer {
 
   async initService() {
     try {
-      if (this.options.forceWebpack === false) {
+      // Allow backwards compatibility without specifying any specific options
+      // The assumption is that WA switched away from Webpack at/after 2.3
+      // This can be removed when all browsers have rolled over to new non-webpack version
+      let useWebpack = false;
+      if (
+        this.options.forceWebpack === false &&
+        this.options.webVersion === false
+      ) {
+        const actualWebVersion = await this.page.evaluate(() => {
+          return window['Debug'] && window['Debug'].VERSION
+            ? window['Debug'].VERSION
+            : '';
+        });
+
+        const versionNumber = parseFloat(actualWebVersion);
+        useWebpack = versionNumber < 2.3;
+      }
+
+      if (this.options.forceWebpack === false && !useWebpack) {
         await this.page.evaluate(() => {
           window['__debug'] = eval("require('__debug');");
         });


### PR DESCRIPTION
Fixes # .
Backwards compatibility

## Changes proposed in this pull request
If no options are set then we should check to see what version of WA is actually running.
If it is less than 2.3 enforce the use of Webpack
Greater than or equal to 2.3 will use new "comet" version

If either options.forceWebpack or options.webVersion are set this will not be processed
-

To test (it takes a while): `npm install github:ghayman/venom#improved-backwards-compatability`
