### PR TITLE
Removed WAPI.waitNewAcknowledgements from middleware

### DIFF
--- a/src/lib/middleware/middleware.ts
+++ b/src/lib/middleware/middleware.ts
@@ -13,8 +13,11 @@ enum ExposedFn {
   });
 });
 
+// This does not appear to be implemented anywhere right now and is breaking code injection via evaluate instead of addScriptTag
+/*
 (window as any).WAPI.waitNewAcknowledgements(function (data: any) {
   if (window[ExposedFn.OnAck]) {
     window[ExposedFn.OnAck](data);
   }
 });
+*/


### PR DESCRIPTION

Fixes #2713

## Changes proposed in this pull request
waitNewAcknowledgements does not seem to be fully implemented. 
The move from addScriptTag to page.evaluate in whatsapp.ts highlighted this issue
Removed the call to the function in middleware.ts

To test (it takes a while): `npm install github:ghayman/venom#window.WAPI.waitNewAcknowledgements-is-not-a-function`
