### PR TITLE
Corrected the order of the parameters sent to WAPI.sendButtons

### DIFF
--- a/src/api/layers/sender.layer.ts
+++ b/src/api/layers/sender.layer.ts
@@ -279,9 +279,9 @@ export class SenderLayer extends AutomateLayer {
   /**
    * Sends a text message to given chat
    * @param to chat id: xxxxx@us.c
-   * @param content text message
-   * @param idMessage add id message
-   * @param passId new id
+   * @param title
+   * @param subtitle
+   * @param buttons
    */
   public async sendButtons(
     to: string,
@@ -330,7 +330,7 @@ export class SenderLayer extends AutomateLayer {
 
       const result = await this.page.evaluate(
         ({ to, title, subtitle, buttons }) => {
-          return WAPI.sendButtons(to, title, buttons, subtitle);
+          return WAPI.sendButtons(to, title, subtitle, buttons);
         },
         { to, title, subtitle, buttons }
       );

--- a/src/types/WAPI.d.ts
+++ b/src/types/WAPI.d.ts
@@ -194,8 +194,8 @@ interface WAPI {
   sendButtons: (
     to: string,
     title: string,
-    buttons: object,
-    subtitle: string
+    subtitle: string,
+    buttons: object
   ) => Promise<object>;
   sendTypeButtons(
     to: string,


### PR DESCRIPTION
Fixes # 2737

## Changes proposed in this pull request
Fixes the order in which arguments are passed to WAPI.sendButtons



To test (it takes a while): `npm install github:ghayman/venom#sendButtons-not-working`
